### PR TITLE
Fix unmarshal error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-sdk/client-dynamodb": "^3.494.0",
         "@aws-sdk/lib-dynamodb": "^3.494.0",
-        "@aws-sdk/util-dynamodb": "^3.494.0",
+        "@aws-sdk/util-dynamodb": "^3.427.0",
         "aws-xray-sdk-core": "^3.5.3",
         "joi": "^17.12.0",
         "ulid": "^2.3.0"
@@ -413,6 +413,20 @@
         "@aws-sdk/client-dynamodb": "^3.0.0"
       }
     },
+    "node_modules/@aws-sdk/lib-dynamodb/node_modules/@aws-sdk/util-dynamodb": {
+      "version": "3.494.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.494.0.tgz",
+      "integrity": "sha512-C4Ggb2UVAj072wumjuwFksbPNmhlHGIZ3HbaJrjimsNwi1oNVuMAWZwipx/VS6vDtsTBlUOZnS2SywFouSXpXA==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/client-dynamodb": "^3.0.0"
+      }
+    },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
       "version": "3.489.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.489.0.tgz",
@@ -561,9 +575,9 @@
       }
     },
     "node_modules/@aws-sdk/util-dynamodb": {
-      "version": "3.494.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.494.0.tgz",
-      "integrity": "sha512-C4Ggb2UVAj072wumjuwFksbPNmhlHGIZ3HbaJrjimsNwi1oNVuMAWZwipx/VS6vDtsTBlUOZnS2SywFouSXpXA==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.427.0.tgz",
+      "integrity": "sha512-eXPdPM7ZIS4DfRJrGeWQJjcxnNAaioRrtgNpRoVy1HwMVYPtUvIyTuUWY8xIeJyXnX3/JrBJWCDoQPxkrp9T2w==",
       "dependencies": {
         "tslib": "^2.5.0"
       },
@@ -1951,6 +1965,16 @@
         "@smithy/smithy-client": "^2.2.1",
         "@smithy/types": "^2.8.0",
         "tslib": "^2.5.0"
+      },
+      "dependencies": {
+        "@aws-sdk/util-dynamodb": {
+          "version": "3.494.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.494.0.tgz",
+          "integrity": "sha512-C4Ggb2UVAj072wumjuwFksbPNmhlHGIZ3HbaJrjimsNwi1oNVuMAWZwipx/VS6vDtsTBlUOZnS2SywFouSXpXA==",
+          "requires": {
+            "tslib": "^2.5.0"
+          }
+        }
       }
     },
     "@aws-sdk/middleware-endpoint-discovery": {
@@ -2077,9 +2101,9 @@
       }
     },
     "@aws-sdk/util-dynamodb": {
-      "version": "3.494.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.494.0.tgz",
-      "integrity": "sha512-C4Ggb2UVAj072wumjuwFksbPNmhlHGIZ3HbaJrjimsNwi1oNVuMAWZwipx/VS6vDtsTBlUOZnS2SywFouSXpXA==",
+      "version": "3.427.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-dynamodb/-/util-dynamodb-3.427.0.tgz",
+      "integrity": "sha512-eXPdPM7ZIS4DfRJrGeWQJjcxnNAaioRrtgNpRoVy1HwMVYPtUvIyTuUWY8xIeJyXnX3/JrBJWCDoQPxkrp9T2w==",
       "requires": {
         "tslib": "^2.5.0"
       }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.494.0",
     "@aws-sdk/lib-dynamodb": "^3.494.0",
-    "@aws-sdk/util-dynamodb": "^3.494.0",
+    "@aws-sdk/util-dynamodb": "^3.427.0",
     "aws-xray-sdk-core": "^3.5.3",
     "joi": "^17.12.0",
     "ulid": "^2.3.0"


### PR DESCRIPTION
Fix for error during unmarshal/convertToNative. Version 3.428 introduces convertWithoutMapWrapper which breaks something